### PR TITLE
メインビジュアル追加修正

### DIFF
--- a/src/app/(home)/components/MainVisual.tsx
+++ b/src/app/(home)/components/MainVisual.tsx
@@ -2,111 +2,90 @@
 
 import React, { useEffect, useState } from "react";
 import Image from "next/image";
-import { Swiper, SwiperSlide } from "swiper/react";
-import { Navigation, Pagination, Autoplay } from "swiper/modules";
-
-import "swiper/css";
-import "swiper/css/navigation";
-import "swiper/css/pagination";
 
 const MainVisual: React.FC = () => {
+  const [currentIndex, setCurrentIndex] = useState(0);
   const [isVisible, setIsVisible] = useState(false);
-
-  useEffect(() => {
-    // コンポーネントがマウントされた後、少し遅延してアニメーションを開始
-    const timer = setTimeout(() => {
-      setIsVisible(true);
-    }, 100);
-
-    return () => clearTimeout(timer);
-  }, []);
 
   const images = [
     "/images/main1.JPG",
     "/images/service.jpeg",
     "/images/menu.JPG",
-    "/images/main1.JPG",
-    "/images/service.jpeg",
-    "/images/menu.JPG",
   ];
 
+  useEffect(() => {
+    setIsVisible(true);
+  }, []);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCurrentIndex((prev) => (prev + 1) % images.length);
+    }, 5000);
+
+    return () => clearInterval(interval);
+  }, [images.length]);
+
   return (
-    <div
-      className={`w-full relative transition-all duration-1000 ease-out transform ${
-        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"
-      }`}
-    >
-      <div className="relative w-full h-[60vh] md:h-[835px]">
-        <Swiper
-          modules={[Navigation, Pagination, Autoplay]}
-          loop={true}
-          centeredSlides={true}
-          autoplay={{
-            delay: 5000,
-            disableOnInteraction: false,
-          }}
-          slidesPerView={1}
-          spaceBetween={0}
-          breakpoints={{
-            1024: {
-              slidesPerView: 1.2,
-              spaceBetween: 40,
-            },
-          }}
-          navigation={{
-            nextEl: ".swiper-button-next-custom",
-            prevEl: ".swiper-button-prev-custom",
-          }}
-          pagination={{
-            el: ".swiper-pagination-custom",
-            clickable: true,
-            renderBullet: (index, className) => {
-              return `<span class="${className} w-2.5 h-2.5 md:w-3 md:h-3 rounded-full bg-white/50 hover:bg-white/80 transition-all duration-300 cursor-pointer inline-block"></span>`;
-            },
-          }}
-          className="w-full h-full"
-        >
-          {images.map((image, index) => (
-            <SwiperSlide key={index}>
-              <div className="relative w-full h-full overflow-hidden">
-                <Image
-                  src={image}
-                  alt={`Main visual ${index + 1}`}
-                  fill
-                  className="object-cover"
-                  priority={index === 0}
-                  sizes="(max-width: 768px) 100vw, 1920px"
-                />
-                <div className="absolute inset-0 bg-black/20" />
-              </div>
-            </SwiperSlide>
-          ))}
-        </Swiper>
+    <div className="w-full relative">
+      <div className="relative w-full h-[60vh] md:h-[835px] overflow-hidden">
+        {images.map((image, index) => (
+          <div
+            key={index}
+            className={`absolute inset-0 transition-opacity duration-1000 ease-in-out ${
+              index === currentIndex ? "opacity-100" : "opacity-0"
+            }`}
+          >
+            <Image
+              src={image}
+              alt={`Background ${index + 1}`}
+              fill
+              className="object-cover"
+              priority={index === 0}
+              sizes="100vw"
+            />
+            {/* 背景画像を薄く表示 */}
+            <div className="absolute inset-0 bg-white/40" />
+          </div>
+        ))}
+
+        {/* テキストオーバーレイ */}
+        <div className="absolute inset-0 flex flex-col items-center justify-center z-10 px-4">
+          <h1
+            className={`text-4xl md:text-7xl font-bold text-gray-800 mb-4 md:mb-6 tracking-wider transition-all duration-1000 delay-300 font-['Noto_Serif_JP'] ${
+              isVisible
+                ? "opacity-100 translate-y-0"
+                : "opacity-0 translate-y-8"
+            }`}
+          >
+            Touch wood
+          </h1>
+          <p
+            className={`text-lg md:text-2xl text-gray-900 font-medium transition-all duration-1000 delay-500 font-['Noto_Serif_JP'] ${
+              isVisible
+                ? "opacity-100 translate-y-0"
+                : "opacity-0 translate-y-8"
+            }`}
+          >
+            お客様の日常に小さな幸せを
+          </p>
+
+          <p
+            className={`text-center mt-10 md:text-xl text-xs text-gray-900 transition-all duration-1000 delay-500 font-['Noto_Serif_JP'] ${
+              isVisible
+                ? "opacity-100 translate-y-0"
+                : "opacity-0 translate-y-8"
+            }`}
+          >
+            出張料理、ケータリングセクションにお問い合わせはこちら
+          </p>
+          <a
+            href="https://yoyaku.tabelog.com/yoyaku/net_booking_form/index?rcd=13311579"
+            className="mt-5 px-6 py-2 bg-Main-Green-2 rounded-full text-System-Gray-White text-xl font-black hover:bg-Main-Green-3 transition-colors duration-300"
+          >
+            Contact
+          </a>
+        </div>
       </div>
-
-      <style jsx global>{`
-        .swiper-slide-prev,
-        .swiper-slide-next {
-          filter: grayscale(100%) brightness(0.8);
-          transition: filter 0.2s ease;
-          transform: scale(0.95);
-        }
-
-        @media (max-width: 1023px) {
-          .swiper-slide-prev,
-          .swiper-slide-next {
-            filter: none;
-            transform: none;
-          }
-        }
-
-        .swiper-pagination-custom .swiper-pagination-bullet-active {
-          background-color: white !important;
-          transform: scale(1.1);
-          box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1),
-            0 2px 4px -1px rgba(0, 0, 0, 0.06);
-        }
-      `}</style>
     </div>
   );
 };


### PR DESCRIPTION
## 修正内容
1. トップページのビジュアル変更
変更後：

- [ ] 横スライドを廃止し、フェードイン・フェードアウト効果（「ボケて次にフェードアウト」）に変更

- [ ] 背景全面に料理写真を配置し、その上に「TOUCH WOOD」「お客様の日常に小さな幸せを」のテキストを重ねる
- [ ] 可読性確保のため背景画像を薄く表示（「ちょっと薄め」の処理）
- [ ] 適用範囲は現在のトップ画像表示部分（コンセプト部分）のみ
- [ ] PC・スマホ両対応で実装
- [ ] 出張料理、ケータリングセクションにお問い合わせはこちらのボタンを設置する。リンクは一旦仮で問い合わせフォームにとばす